### PR TITLE
AGR-2037, AGR-1864, AGR-1823, AGR-1283 code structure for alliance headers, some values are placeho…

### DIFF
--- a/src/default_env_vars.yml
+++ b/src/default_env_vars.yml
@@ -6,7 +6,7 @@ ALLIANCE_RELEASE: "0.0.0"
 NEO4J_HOST: "localhost"
 NEO4J_PORT: 7687
 FMS_API_URL: "https://fms.alliancegenome.org"
-HEADER_TEMPLATE_URL: "https://raw.githubusercontent.com/alliance-genome/agr_file_generator/master/src/generators/header_template.txt"
+HEADER_TEMPLATE_URL: "https://raw.githubusercontent.com/alliance-genome/agr_file_generator/6fea7c7a12ef8f53de17f31f8a8bd3b468cb41e7/src/generators/header_template.txt"
 TEST_SET: false
 AWS_ACCESS_KEY: ""
 AWS_SECRET_KEY: ""

--- a/src/default_env_vars.yml
+++ b/src/default_env_vars.yml
@@ -6,6 +6,7 @@ ALLIANCE_RELEASE: "0.0.0"
 NEO4J_HOST: "localhost"
 NEO4J_PORT: 7687
 FMS_API_URL: "https://fms.alliancegenome.org"
+HEADER_TEMPLATE_URL: "https://raw.githubusercontent.com/alliance-genome/agr_file_generator/master/src/generators/header_template.txt"
 TEST_SET: false
 AWS_ACCESS_KEY: ""
 AWS_SECRET_KEY: ""

--- a/src/processor/interaction_genetic_processor.py
+++ b/src/processor/interaction_genetic_processor.py
@@ -5,7 +5,6 @@ import re
 import json
 import os
 import sys
-# import strict_rfc3339
 import urllib.request
 import requests
 from tqdm import tqdm
@@ -344,7 +343,8 @@ class InteractionGeneticProcessor(Processor):
             skipped_out = csv.writer(skipped_out, quotechar = '', quoting=csv.QUOTE_NONE, delimiter='\t')
             mapped_out = csv.writer(mapped_out, quotechar = '', quoting=csv.QUOTE_NONE, delimiter='\t')
 
-            out_write_list = [fb_out, wb_out, zfin_out, sgd_out, rgd_out, mgi_out, human_out]
+            # This list is now sorted phylogenetically for the header to be sorted
+            out_write_list = [human_out, rgd_out, mgi_out, zfin_out, fb_out, wb_out, sgd_out]
 
             taxon_file_dispatch_dict = {
                 'taxid:10116': rgd_out,
@@ -373,17 +373,34 @@ class InteractionGeneticProcessor(Processor):
                 fb_out: 'Drosophila melanogaster'
             }
 
+            out_to_header_taxonid_dict = {
+                rgd_out: 'NCBI:txid10116',
+                human_out: 'NCBI:txid9606',
+                mgi_out: 'NCBI:txid10090',
+                wb_out: 'NCBI:txid6239',
+                sgd_out: 'NCBI:txid559292',
+                zfin_out: 'NCBI:txid7955',
+                fb_out: 'NCBI:txid7227'
+            }
+
             # Write the comments in the main file.
             filetype = 'Genetic Interactions'
             data_format = 'PSI-MI TAB 2.7 Format'
             database_version = self.context_info.env["ALLIANCE_RELEASE"]
-            species = 'Many'
+            species_list = []
+            taxon_list = []
+            for entry in out_write_list:
+                taxon_list.append(out_to_header_taxonid_dict[entry])
+                species_list.append(out_to_species_name_dict[entry])
+            species = ", ".join(species_list)
+            taxon_ids = ", ".join(taxon_list)
+            taxon_ids = '# TaxonIDs: {}'.format(taxon_ids)
             gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
-            readme = 'Readme placeholder'
+            readme = 'https://github.com/HUPO-PSI/miTab/blob/master/PSI-MITAB27Format.md'
             response = urllib.request.urlopen(self.context_info.env["HEADER_TEMPLATE_URL"])
             header_template = HeaderTemplate(response.read().decode('ascii'))
             header_dict = {'filetype': filetype, 'data_format': data_format, 'stringency_filter': '',
-                           'taxon_ids': '', 'database_version': database_version, 'species': species, 
+                           'taxon_ids': taxon_ids, 'database_version': database_version, 'species': species, 
                            'gen_time': gen_time, 'readme': readme}
             header = header_template.substitute(header_dict)
             header_rows = [line.strip() for line in header.splitlines() if len(line.strip()) != 0]
@@ -392,46 +409,17 @@ class InteractionGeneticProcessor(Processor):
             tsvout.writerow(psi_mi_tab_header)
 
             for entry in out_write_list:
-                filetype = 'Genetic Interactions for {}'.format(out_to_species_name_dict[entry])
+                filetype = 'Genetic Interactions'
                 species = out_to_species_name_dict[entry]
+                taxon_ids = '# TaxonIDs: {}'.format(out_to_header_taxonid_dict[entry])
                 header_dict = {'filetype': filetype, 'data_format': data_format, 'stringency_filter': '',
-                               'taxon_ids': '', 'database_version': database_version, 'species': species, 
+                               'taxon_ids': taxon_ids, 'database_version': database_version, 'species': species, 
                                'gen_time': gen_time, 'readme': readme}
                 header = header_template.substitute(header_dict)
                 header_rows = [line.strip() for line in header.splitlines() if len(line.strip()) != 0]
                 for header_row in header_rows:
                     entry.writerow([header_row])
                 entry.writerow(psi_mi_tab_header)
-
-
-#           Old format for headers
-#
-#           the_time = strict_rfc3339.now_to_rfc3339_localoffset()
-#           tsvout.writerow(['# Genetic Interactions'])
-#           tsvout.writerow(['# Alliance of Genome Resources'])
-#           tsvout.writerow(['# alliancegenome.org'])
-#           tsvout.writerow(['# alliance-helpdesk@lists.stanford.edu'])
-#           tsvout.writerow(['#'])
-#           tsvout.writerow(['# PSI-MI TAB 2.7 Format'])
-#           tsvout.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
-#           tsvout.writerow(['# Date Produced: {}'.format(the_time)])
-#           tsvout.writerow(['#'])
-#           # Write the headers
-#           tsvout.writerow(psi_mi_tab_header)
-# 
-#           for entry in out_write_list:
-#               the_time = strict_rfc3339.now_to_rfc3339_localoffset()
-#               entry.writerow(['# Genetic Interactions for {}'.format(out_to_species_name_dict[entry])])
-#               entry.writerow(['# Alliance of Genome Resources'])
-#               entry.writerow(['# alliancegenome.org'])
-#               entry.writerow(['# alliance-helpdesk@lists.stanford.edu'])
-#               entry.writerow(['#'])
-#               entry.writerow(['# PSI-MI TAB 2.7 Format'])
-#               entry.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
-#               entry.writerow(['# Date Produced: {}'.format(the_time)])
-#               entry.writerow(['#'])
-#               # Write the headers
-#               entry.writerow(psi_mi_tab_header)
 
             psi_mi_tab_header.insert(0,'Reason for skipping row.')
             skipped_out.writerow(psi_mi_tab_header)
@@ -456,12 +444,6 @@ class InteractionGeneticProcessor(Processor):
                     for row in tqdm(csv_reader):
                         if row[0].startswith("#"):
                             row.insert(0,'Entry starts with # commented out or header')
-                            skipped_out.writerow(row)
-                            continue
-
-                        # Skip entries with unassigned pubmed IDs.
-                        if 'pubmed:unassigned' in row[8]:
-                            row.insert(0,'Entry contains a pubmed:unassigned identifier.')
                             skipped_out.writerow(row)
                             continue
 

--- a/src/processor/interaction_genetic_processor.py
+++ b/src/processor/interaction_genetic_processor.py
@@ -5,14 +5,21 @@ import re
 import json
 import os
 import sys
-import strict_rfc3339
+# import strict_rfc3339
+import urllib.request
 import requests
 from tqdm import tqdm
+from datetime import datetime
+from string import Template
+
 
 from processor import Processor
 
 logger = logging.getLogger(__name__)
 
+
+class HeaderTemplate(Template):
+    delimiter = '%'
 
 
 class InteractionGeneticProcessor(Processor):
@@ -367,32 +374,64 @@ class InteractionGeneticProcessor(Processor):
             }
 
             # Write the comments in the main file.
-            the_time = strict_rfc3339.now_to_rfc3339_localoffset()
-            tsvout.writerow(['# Genetic Interactions'])
-            tsvout.writerow(['# Alliance of Genome Resources'])
-            tsvout.writerow(['# alliancegenome.org'])
-            tsvout.writerow(['# alliance-helpdesk@lists.stanford.edu'])
-            tsvout.writerow(['#'])
-            tsvout.writerow(['# PSI-MI TAB 2.7 Format'])
-            tsvout.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
-            tsvout.writerow(['# Date Produced: {}'.format(the_time)])
-            tsvout.writerow(['#'])
-            # Write the headers
+            filetype = 'Genetic Interactions'
+            data_format = 'PSI-MI TAB 2.7 Format'
+            database_version = self.context_info.env["ALLIANCE_RELEASE"]
+            species = 'Many'
+            gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
+            readme = 'Readme placeholder'
+            response = urllib.request.urlopen(self.context_info.env["HEADER_TEMPLATE_URL"])
+            header_template = HeaderTemplate(response.read().decode('ascii'))
+            header_dict = {'filetype': filetype, 'data_format': data_format, 'stringency_filter': '',
+                           'taxon_ids': '', 'database_version': database_version, 'species': species, 
+                           'gen_time': gen_time, 'readme': readme}
+            header = header_template.substitute(header_dict)
+            header_rows = [line.strip() for line in header.splitlines() if len(line.strip()) != 0]
+            for header_row in header_rows:
+                tsvout.writerow([header_row])
             tsvout.writerow(psi_mi_tab_header)
 
             for entry in out_write_list:
-                the_time = strict_rfc3339.now_to_rfc3339_localoffset()
-                entry.writerow(['# Genetic Interactions for {}'.format(out_to_species_name_dict[entry])])
-                entry.writerow(['# Alliance of Genome Resources'])
-                entry.writerow(['# alliancegenome.org'])
-                entry.writerow(['# alliance-helpdesk@lists.stanford.edu'])
-                entry.writerow(['#'])
-                entry.writerow(['# PSI-MI TAB 2.7 Format'])
-                entry.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
-                entry.writerow(['# Date Produced: {}'.format(the_time)])
-                entry.writerow(['#'])
-                # Write the headers
+                filetype = 'Genetic Interactions for {}'.format(out_to_species_name_dict[entry])
+                species = out_to_species_name_dict[entry]
+                header_dict = {'filetype': filetype, 'data_format': data_format, 'stringency_filter': '',
+                               'taxon_ids': '', 'database_version': database_version, 'species': species, 
+                               'gen_time': gen_time, 'readme': readme}
+                header = header_template.substitute(header_dict)
+                header_rows = [line.strip() for line in header.splitlines() if len(line.strip()) != 0]
+                for header_row in header_rows:
+                    entry.writerow([header_row])
                 entry.writerow(psi_mi_tab_header)
+
+
+#           Old format for headers
+#
+#           the_time = strict_rfc3339.now_to_rfc3339_localoffset()
+#           tsvout.writerow(['# Genetic Interactions'])
+#           tsvout.writerow(['# Alliance of Genome Resources'])
+#           tsvout.writerow(['# alliancegenome.org'])
+#           tsvout.writerow(['# alliance-helpdesk@lists.stanford.edu'])
+#           tsvout.writerow(['#'])
+#           tsvout.writerow(['# PSI-MI TAB 2.7 Format'])
+#           tsvout.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
+#           tsvout.writerow(['# Date Produced: {}'.format(the_time)])
+#           tsvout.writerow(['#'])
+#           # Write the headers
+#           tsvout.writerow(psi_mi_tab_header)
+# 
+#           for entry in out_write_list:
+#               the_time = strict_rfc3339.now_to_rfc3339_localoffset()
+#               entry.writerow(['# Genetic Interactions for {}'.format(out_to_species_name_dict[entry])])
+#               entry.writerow(['# Alliance of Genome Resources'])
+#               entry.writerow(['# alliancegenome.org'])
+#               entry.writerow(['# alliance-helpdesk@lists.stanford.edu'])
+#               entry.writerow(['#'])
+#               entry.writerow(['# PSI-MI TAB 2.7 Format'])
+#               entry.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
+#               entry.writerow(['# Date Produced: {}'.format(the_time)])
+#               entry.writerow(['#'])
+#               # Write the headers
+#               entry.writerow(psi_mi_tab_header)
 
             psi_mi_tab_header.insert(0,'Reason for skipping row.')
             skipped_out.writerow(psi_mi_tab_header)

--- a/src/processor/interaction_molecular_processor.py
+++ b/src/processor/interaction_molecular_processor.py
@@ -5,7 +5,6 @@ import re
 import json
 import os
 import sys
-# import strict_rfc3339
 import urllib.request
 import requests
 from tqdm import tqdm
@@ -32,7 +31,7 @@ class InteractionMolecularProcessor(Processor):
         self.master_crossreference_dictionary['UniProtKB'] = dict()
         self.master_crossreference_dictionary['ENSEMBL'] = dict()
         self.master_crossreference_dictionary['NCBI_Gene'] = dict()
-        self.biogrid_ignore_set = set()
+        self.biogrid_rna_set = set()
         self.output_dir = '/usr/src/app/output/'
         self.download_dir = '/usr/src/app/download_molecular/'
 
@@ -225,13 +224,13 @@ class InteractionMolecularProcessor(Processor):
             os.system('mv {}tmp/* {}'.format(self.download_dir, filename))
 
 
-    def create_rna_protein_ignore(self, tab20_filename):
-        with open(tab20_filename, 'r', encoding='utf-8') as tab20in:
-            csv_reader = csv.reader(tab20in, delimiter='\t', quoting=csv.QUOTE_NONE)
+    def create_rna_protein_set(self, tab30_filename):
+        with open(tab30_filename, 'r', encoding='utf-8') as tab30in:
+            csv_reader = csv.reader(tab30in, delimiter='\t', quoting=csv.QUOTE_NONE)
             next(csv_reader, None) # Skip the headers
             for row in tqdm(csv_reader):
                 if 'RNA' in row[11]:
-                    self.biogrid_ignore_set.add(row[0])
+                    self.biogrid_rna_set.add(row[0])
 
 
     def get_data(self):
@@ -251,14 +250,14 @@ class InteractionMolecularProcessor(Processor):
         imex_filename = self.download_dir + 'INTERACTION-MOL_IMEX'
         biogrid_filename_zip = source_filepaths['BIOGRID']
         biogrid_filename = self.download_dir + 'INTERACTION-MOL_BIOGRID'
-        tab20_filename_zip = source_filepaths['BIOGRID-TAB']
-        tab20_filename = self.download_dir + 'INTERACTION-MOL_BIOGRID-TAB'
+        tab30_filename_zip = source_filepaths['BIOGRID-TAB']
+        tab30_filename = self.download_dir + 'INTERACTION-MOL_BIOGRID-TAB'
 
         self.unzip_to_filename(imex_filename_zip, imex_filename, 'IMEX')
         self.unzip_to_filename(biogrid_filename_zip, biogrid_filename, 'BIOGRID')
-        self.unzip_to_filename(tab20_filename_zip, tab20_filename, 'BIOGRID-TAB')
+        self.unzip_to_filename(tab30_filename_zip, tab30_filename, 'BIOGRID-TAB')
 
-        self.create_rna_protein_ignore(imex_filename)
+        self.create_rna_protein_set(tab30_filename)
 
         # The order of this list is important.
         parsing_list = [wormbase_filename, flybase_filename, biogrid_filename, imex_filename]
@@ -355,7 +354,8 @@ class InteractionMolecularProcessor(Processor):
             mgi_out = csv.writer(mgi_out, quotechar='', quoting=csv.QUOTE_NONE, delimiter='\t')
             human_out = csv.writer(human_out, quotechar='', quoting=csv.QUOTE_NONE, delimiter='\t')
 
-            out_write_list = [fb_out, wb_out, zfin_out, sgd_out, rgd_out, mgi_out, human_out]
+            # This list is now sorted phylogenetically for the header to be sorted
+            out_write_list = [human_out, rgd_out, mgi_out, zfin_out, fb_out, wb_out, sgd_out]
 
             taxon_file_dispatch_dict = {
                 'taxid:10116': rgd_out,
@@ -384,17 +384,34 @@ class InteractionMolecularProcessor(Processor):
                 fb_out: 'Drosophila melanogaster'
             }
 
+            out_to_header_taxonid_dict = {
+                rgd_out: 'NCBI:txid10116',
+                human_out: 'NCBI:txid9606',
+                mgi_out: 'NCBI:txid10090',
+                wb_out: 'NCBI:txid6239',
+                sgd_out: 'NCBI:txid559292',
+                zfin_out: 'NCBI:txid7955',
+                fb_out: 'NCBI:txid7227'
+            }
+
             # Write the comments in the main file.
             filetype = 'Molecular Interactions'
             data_format = 'PSI-MI TAB 2.7 Format'
             database_version = self.context_info.env["ALLIANCE_RELEASE"]
-            species = 'Many'
+            species_list = []
+            taxon_list = []
+            for entry in out_write_list:
+                taxon_list.append(out_to_header_taxonid_dict[entry])
+                species_list.append(out_to_species_name_dict[entry])
+            species = ", ".join(species_list)
+            taxon_ids = ", ".join(taxon_list)
+            taxon_ids = '# TaxonIDs: {}'.format(taxon_ids)
             gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
-            readme = 'Readme placeholder'
+            readme = 'https://github.com/HUPO-PSI/miTab/blob/master/PSI-MITAB27Format.md'
             response = urllib.request.urlopen(self.context_info.env["HEADER_TEMPLATE_URL"])
             header_template = HeaderTemplate(response.read().decode('ascii'))
             header_dict = {'filetype': filetype, 'data_format': data_format, 'stringency_filter': '',
-                           'taxon_ids': '', 'database_version': database_version, 'species': species,
+                           'taxon_ids': taxon_ids, 'database_version': database_version, 'species': species,
                            'gen_time': gen_time, 'readme': readme}
             header = header_template.substitute(header_dict)
             header_rows = [line.strip() for line in header.splitlines() if len(line.strip()) != 0]
@@ -403,45 +420,17 @@ class InteractionMolecularProcessor(Processor):
             tsvout.writerow(psi_mi_tab_header)
 
             for entry in out_write_list:
-                filetype = 'Molecular Interactions for {}'.format(out_to_species_name_dict[entry])
+                filetype = 'Molecular Interactions'
                 species = out_to_species_name_dict[entry]
+                taxon_ids = '# TaxonIDs: {}'.format(out_to_header_taxonid_dict[entry])
                 header_dict = {'filetype': filetype, 'data_format': data_format, 'stringency_filter': '',
-                               'taxon_ids': '', 'database_version': database_version, 'species': species,
+                               'taxon_ids': taxon_ids, 'database_version': database_version, 'species': species,
                                'gen_time': gen_time, 'readme': readme}
                 header = header_template.substitute(header_dict)
                 header_rows = [line.strip() for line in header.splitlines() if len(line.strip()) != 0]
                 for header_row in header_rows:
                     entry.writerow([header_row])
                 entry.writerow(psi_mi_tab_header)
-
-#           Old format for headers
-# 
-#           the_time = strict_rfc3339.now_to_rfc3339_localoffset()
-#           tsvout.writerow(['# Molecular Interactions'])
-#           tsvout.writerow(['# Alliance of Genome Resources'])
-#           tsvout.writerow(['# alliancegenome.org'])
-#           tsvout.writerow(['# alliance-helpdesk@lists.stanford.edu'])
-#           tsvout.writerow(['#'])
-#           tsvout.writerow(['# PSI-MI TAB 2.7 Format'])
-#           tsvout.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
-#           tsvout.writerow(['# Date Produced: {}'.format(the_time)])
-#           tsvout.writerow(['#'])
-#           # Write the headers
-#           tsvout.writerow(psi_mi_tab_header)
-#
-#           for entry in out_write_list:
-#               the_time = strict_rfc3339.now_to_rfc3339_localoffset()
-#               entry.writerow(['# Molecular Interactions for {}'.format(out_to_species_name_dict[entry])])
-#               entry.writerow(['# Alliance of Genome Resources'])
-#               entry.writerow(['# alliancegenome.org'])
-#               entry.writerow(['# alliance-helpdesk@lists.stanford.edu'])
-#               entry.writerow(['#'])
-#               entry.writerow(['# PSI-MI TAB 2.7 Format'])
-#               entry.writerow(['# Alliance Version {}'.format(self.context_info.env['ALLIANCE_RELEASE'])])
-#               entry.writerow(['# Date Produced: {}'.format(the_time)])
-#               entry.writerow(['#'])
-#               # Write the headers
-#               entry.writerow(psi_mi_tab_header)
 
             psi_mi_tab_header.insert(0,'Reason for skipping row.')
             skipped_out.writerow(psi_mi_tab_header)
@@ -471,19 +460,8 @@ class InteractionMolecularProcessor(Processor):
                             skipped_out.writerow(row)
                             continue
 
-                        # Skip entries with unassigned pubmed IDs.
-                        if 'pubmed:unassigned' in row[8]:
-                            row.insert(0,'Entry contains a pubmed:unassigned identifier.')
-                            skipped_out.writerow(row)
-                            continue
-
                         if filename_type == 'biogrid':
                             biogrid_interaction_id = re.findall(r'\d+', row[13])[0]
-                            # Exclude interations from the biogrid_prot_rna_set.
-                            if biogrid_interaction_id in self.biogrid_ignore_set:
-                                row.insert(0,'Entry appears in biogrid protein-rna filter set.')
-                                skipped_out.writerow(row)
-                                continue
                             # We need to add '-' characters to columns 17-42 for biogrid entries.
                             for _ in range(17,43):
                                 row.append('-')
@@ -492,6 +470,8 @@ class InteractionMolecularProcessor(Processor):
                             row[19] = 'psi-mi:\"MI:0498\"(prey)'
                             row[20] = 'psi-mi:\"MI:0326\"(protein)'
                             row[21] = 'psi-mi:\"MI:0326\"(protein)'
+                            if biogrid_interaction_id in self.biogrid_rna_set:
+                                row[21] = 'psi-mi:\"MI:0320\"(ribonucleic acid)'
                             row[35] = 'false'
 
                         try:


### PR DESCRIPTION
AGR-2037 Headers based on  agr_file_generator repo blob/master/src/generators/header.py and Valerio's code in agr_loader repo.  Strips out blank lines from header (not sure if we should).  Has placeholders for some values, like readme, and species for combined file.  Does not have taxon IDs, but maybe it should.

Could be pulled, but probably should update those variables first.