### PR TITLE
SCRUM-319 - Add biogrid prefix to each ontology term

### DIFF
--- a/src/processor/interaction_genetic_processor.py
+++ b/src/processor/interaction_genetic_processor.py
@@ -501,9 +501,8 @@ class InteractionGeneticProcessor(Processor):
                             for entry in ontology_terms:
                                 entry = re.sub(r":type:([^:]+)$", r";type(\1)", entry)
                                 entry = re.sub(r":", r"_", entry)
-                                parsed_ontology_terms.append(entry)
+                                parsed_ontology_terms.append('biogrid:' + entry)
                             ontology_terms = "|".join(parsed_ontology_terms)
-                            ontology_terms = 'biogrid:' + ontology_terms
 
                             # We need to add '-' characters to columns 17-42 for biogrid entries.
                             for _ in range(17,43):


### PR DESCRIPTION
@azurebrd - I believe that according to the MITAB27 spec (https://psicquic.github.io/MITAB27Format.html) the 'biogrid:' prefix should be applied to each ontology term in cases where there are multiple terms.  This matches how multiple entries are dealt with in other columns and currently the single prefix is causing a loader failure.