### PR TITLE
SCRUM-4788: Upload preprocessed files to S3 alongside FMS upload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ strict-rfc3339
 requests
 jsonref
 cerberus
+boto3

--- a/src/default_env_vars.yml
+++ b/src/default_env_vars.yml
@@ -7,7 +7,9 @@ NEO4J_PORT: 7687
 FMS_API_URL: "https://fms.alliancegenome.org"
 HEADER_TEMPLATE_URL: "https://raw.githubusercontent.com/alliance-genome/agr_file_generator/6fea7c7a12ef8f53de17f31f8a8bd3b468cb41e7/src/generators/header_template.txt"
 TEST_SET: false
+AWS_PROFILE: ""
 AWS_ACCESS_KEY: ""
 AWS_SECRET_KEY: ""
 API_KEY: ""
 SAVE_PATH: "/usr/src/app/tmp"
+S3_BUCKET: "mod-datadumps"

--- a/src/processor/processor.py
+++ b/src/processor/processor.py
@@ -5,6 +5,10 @@ from common import ContextInfo
 import requests
 import gzip
 import shutil
+import boto3
+from botocore.credentials import InstanceMetadataProvider
+from botocore.utils import InstanceMetadataFetcher
+from botocore.session import Session as BotocoreSession
 
 logger = logging.getLogger(__name__)
 
@@ -85,3 +89,40 @@ class Processor(object):
 
         response = requests.post(self.context_info.env['FMS_API_URL'] + '/api/data/submit/', files=file_to_upload, headers=headers)
         logger.info(response.text)
+
+        self.s3_upload(filepath_compressed)
+
+    def s3_upload(self, filepath_compressed):
+        bucket = self.context_info.env['S3_BUCKET']
+        release = self.context_info.env['ALLIANCE_RELEASE']
+        local_path = self.output_dir + filepath_compressed
+        s3_key = '{}/downloads/{}'.format(release, os.path.basename(filepath_compressed))
+
+        s3_client = self._build_s3_client()
+
+        logger.info('Uploading %s to s3://%s/%s', local_path, bucket, s3_key)
+        s3_client.upload_file(local_path, bucket, s3_key)
+        logger.info('Uploaded s3://%s/%s', bucket, s3_key)
+
+    def _build_s3_client(self):
+        profile = self.context_info.env.get('AWS_PROFILE')
+        access_key = self.context_info.env.get('AWS_ACCESS_KEY')
+        secret_key = self.context_info.env.get('AWS_SECRET_KEY')
+
+        if profile:
+            logger.info('Using AWS profile: %s', profile)
+            return boto3.Session(profile_name=profile).client('s3')
+
+        if access_key and secret_key:
+            logger.info('Using static AWS access keys')
+            return boto3.client('s3', aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+
+        instance_creds = InstanceMetadataProvider(iam_role_fetcher=InstanceMetadataFetcher(timeout=2, num_attempts=2)).load()
+        if instance_creds is not None:
+            logger.info('Using EC2 instance profile credentials')
+            botocore_session = BotocoreSession()
+            botocore_session._credentials = instance_creds
+            return boto3.Session(botocore_session=botocore_session).client('s3')
+
+        logger.info('Using default AWS credential chain')
+        return boto3.client('s3')


### PR DESCRIPTION
## Summary
- After each FMS upload in `Processor.fms_upload`, also upload the gzipped file to `s3://{S3_BUCKET}/{ALLIANCE_RELEASE}/downloads/`
- New env var `S3_BUCKET` (default `mod-datadumps`)
- New env var `AWS_PROFILE` for credential resolution
- Credential precedence: `AWS_PROFILE` -> static `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` -> EC2 instance profile -> default boto3 chain
- Adds `boto3` to `requirements.txt`

Backs ticket [SCRUM-4788](https://agr-jira.atlassian.net/browse/SCRUM-4788) — putting molecular interaction download files in the right S3 location for the Downloads page.

## Test plan
- [ ] Verify `mod-datadumps` bucket receives files at `{ALLIANCE_RELEASE}/downloads/<filename>.gz`
- [ ] Verify FMS upload still succeeds (unchanged path)
- [ ] Verify credential precedence works on stage EC2 (instance profile path)

[SCRUM-4788]: https://agr-jira.atlassian.net/browse/SCRUM-4788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ