### PR TITLE
SCRUM-4788: Rename S3 download files to {dataType}_{FORMAT}_{dataSubType}

### DIFF
--- a/src/processor/processor.py
+++ b/src/processor/processor.py
@@ -90,13 +90,17 @@ class Processor(object):
         response = requests.post(self.context_info.env['FMS_API_URL'] + '/api/data/submit/', files=file_to_upload, headers=headers)
         logger.info(response.text)
 
-        self.s3_upload(filepath_compressed)
+        self.s3_upload(dataType, dataSubType, filepath_uncompressed, filepath_compressed)
 
-    def s3_upload(self, filepath_compressed):
+    def s3_upload(self, dataType, dataSubType, filepath_uncompressed, filepath_compressed):
         bucket = self.context_info.env['S3_BUCKET']
         release = self.context_info.env['ALLIANCE_RELEASE']
         local_path = self.output_dir + filepath_compressed
-        s3_key = '{}/downloads/{}'.format(release, os.path.basename(filepath_compressed))
+
+        ext = os.path.splitext(filepath_uncompressed)[1].lstrip('.').lower()
+        format_label = ext.upper()
+        s3_filename = '{}_{}_{}.{}.gz'.format(dataType, format_label, dataSubType, ext)
+        s3_key = '{}/downloads/{}'.format(release, s3_filename)
 
         s3_client = self._build_s3_client()
 


### PR DESCRIPTION
## Summary
- Rename uploaded S3 files in `Processor.s3_upload` to match the existing download bucket convention: `{dataType}_{FORMAT}_{dataSubType}.{ext}.gz`
- Example: `INTERACTION-MOL_TSV_HUMAN.tsv.gz` (instead of the local processor filename `alliance_molecular_interactions_human.tsv.gz`)
- `FORMAT` is derived from the uncompressed file extension (e.g. `tsv` -> `TSV`)

Follow-up to the merged S3 upload PR for [SCRUM-4788](https://agr-jira.atlassian.net/browse/SCRUM-4788). The download index at https://download.alliancegenome.org expects this `INTERACTION-*_TSV_*` naming.

## Test plan
- [ ] Verify uploaded files in `s3://mod-datadumps/{ALLIANCE_RELEASE}/downloads/` match `INTERACTION-MOL_TSV_<SUBTYPE>.tsv.gz` and `INTERACTION-GEN_TSV_<SUBTYPE>.tsv.gz`
- [ ] Verify FMS upload behavior is unchanged

[SCRUM-4788]: https://agr-jira.atlassian.net/browse/SCRUM-4788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ